### PR TITLE
Use UUID4 for filenames

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "solid-comment",
-  "version": "0.4.0",
+  "version": "0.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.4.0",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "@inrupt/solid-client": "^1.5.0",
@@ -16,7 +16,8 @@
         "lodash.isnil": "^4.0.0",
         "lodash.isstring": "^4.0.1",
         "lodash.isundefined": "^3.0.1",
-        "lodash.kebabcase": "^4.1.1"
+        "lodash.kebabcase": "^4.1.1",
+        "uuid": "^3.4.0"
       },
       "devDependencies": {
         "@babel/cli": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,11 @@
     "json-server": "json-server db.json -p 3001",
     "test": "jest"
   },
-  "keywords": ["solid", "comment", "indico"],
+  "keywords": [
+    "solid",
+    "comment",
+    "indico"
+  ],
   "author": "Jan Schill",
   "license": "MIT",
   "dependencies": {
@@ -26,7 +30,8 @@
     "lodash.isnil": "^4.0.0",
     "lodash.isstring": "^4.0.1",
     "lodash.isundefined": "^3.0.1",
-    "lodash.kebabcase": "^4.1.1"
+    "lodash.kebabcase": "^4.1.1",
+    "uuid": "^3.4.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",

--- a/src/models/solid-model.js
+++ b/src/models/solid-model.js
@@ -1,3 +1,4 @@
+import { v4 as uuidv4 } from 'uuid'
 import {
   addStringNoLocale,
   addUrl,
@@ -29,8 +30,9 @@ export default class SolidModel extends ActiveRecord {
 
   getResourceName () {
     const fileExtension = '.ttl'
+    const uuid = uuidv4()
 
-    return `${this.timeStripped}${fileExtension}`
+    return `${this.timeStripped}_${uuid}${fileExtension}`
   }
 
   getResourceContainerUrl (author) {

--- a/test/integration/uuid.test.js
+++ b/test/integration/uuid.test.js
@@ -1,0 +1,13 @@
+import { v4 as uuidv4 } from 'uuid'
+
+describe('uuid', () => {
+  describe('uuidv4', () => {
+    it('does not return the same string on consecutive calls', () => {
+      expect(uuidv4()).not.toBe(uuidv4())
+    })
+    it('returns a string', () => {
+      const uuid = uuidv4()
+      expect(typeof uuid === 'string' || uuid instanceof String).toBeTruthy()
+    })
+  })
+})


### PR DESCRIPTION
Filenames should be non-guessable as they are all public and can be seen by anyone who posses the URL to it or can guess it. UUID generate 128 bit long randomly generated strings/numbers that are globally unique (close to 0% change of duplicates). This makes guessing the filenames near to impossible.

The datetime string should still be part of the filename.